### PR TITLE
Fix for bad header error.

### DIFF
--- a/endpoints/jqueryFileTree.php
+++ b/endpoints/jqueryFileTree.php
@@ -207,7 +207,7 @@ if($request['dir'] == DSEP && count($allowed_folders)) {
 
 }
 
-header('Content-type', 'application/json');
+header('Content-Type: application/json');
 echo(json_encode($returnData));
 
 


### PR DESCRIPTION
The dialog box for choosing a CD/DVD image does not work due to a "Malformed header" bug. The reason is that the header directive is not correct.